### PR TITLE
Fix some doc issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,18 @@ Dev Environment Setup
 =====================
 - Prerequisite:
     - python 3.6+  
+    - R
 - It is preferable to have a dedicated virtualenv for this project:
 ```
     $ git clone <this repo>
-    $ cd Tyrell
+    $ cd Trinity
     $ mkdir venv
     $ python3 -m venv venv
     $ source venv/bin/activate
 ```
 - Make an editable install with `pip`. This would automatically handles package dependencies. One of our dependency, `z3-solver`, takes a long time to build. Please be patient.
 ```
+    $ pip install wheel
     $ pip install -e ".[dev]"
     $ python setup.py sdist  # for package
 ```

--- a/docs/tutorial/01_language.rst
+++ b/docs/tutorial/01_language.rst
@@ -94,7 +94,7 @@ The :func:`~tyrell.spec.do_parse.parse_file` function takes file path as a param
 .. code-block:: python
 
   from tyrell.spec import parse
-  spec = parse_file(r'''
+  spec = parse(r'''
       enum IntConst {
         "0", "1", "2"
       }
@@ -176,9 +176,9 @@ For example, a simple interpreter for the small language we defined in the previ
 
   # Create the interpreter object and run it
   interp = BinaryArithFuncInterpreter()
-  print(interp.eval(builder.from_sexp_string('(@param 0)', [3, 4])))    # Prints 0
-  print(interp.eval(builder.from_sexp_string('(const (IntConst 1))', [3, 4])))  # Prints 0
-  print(interp.eval(builder.from_sexp_string('(plus (@param 1) (IntConst 2))', [3, 4])))  # Prints 0
+  print(interp.eval(builder.from_sexp_string('(@param 0)'), [3, 4]))    # Prints 0
+  print(interp.eval(builder.from_sexp_string('(const (IntConst 1))'), [3, 4]))  # Prints 0
+  print(interp.eval(builder.from_sexp_string('(plus (@param 1) (const (IntConst 2)))'), [3, 4]))  # Prints 0
 
 Well, this is not a super interesting interpreter, as it interprets any program to ``0``. To make it more interesting, we could have examined what the structure of ``node`` is, and take different actions according to whether it's a parameter, an enum, or a function application (in which case you may need to recurse down and interpret its arguments).
 


### PR DESCRIPTION
The changes to `docs/tutorial/01_language.rst` are just typo fixes. The changes to `README.md` were found necessary while building [this Dockerfile][1].

[1]: https://gitlab.com/GrammaTech/Mnemosyne/muses/trinity/-/blob/80227b58/Dockerfile